### PR TITLE
fix: Remove unnecessary as any cast for placeType

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1013,7 +1013,7 @@ export default class CanvasRootsPlugin extends Plugin {
 						new CreatePlaceModal(this.app, {
 							directory: this.settings.placesFolder || '',
 							initialName: result.standardizedName,
-							initialPlaceType: result.placeType as any,
+							initialPlaceType: result.placeType,
 							familyGraph: this.createFamilyGraphService(),
 							placeGraph: this.createPlaceGraphService(),
 							settings: this.settings,


### PR DESCRIPTION
## Description

Removes unnecessary `as any` type cast at main.ts:1016.

**Change:**
```diff
- initialPlaceType: result.placeType as any,
+ initialPlaceType: result.placeType,
```

**Type Analysis:**
- `result.placeType` is `string | undefined`
- `CreatePlaceModal` expects `initialPlaceType?: PlaceType`
- `PlaceType` is `type PlaceType = string;`
- Types are identical - cast was never needed

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

### Automated
- [x] `npm run lint` passes (no type errors)
- [x] `npm run lint:css` passes
- [x] `npm run build` succeeds

### Manual Testing in Obsidian
1. Deploy plugin: `npm run deploy`
2. Reload Obsidian (Cmd+R)
3. Open Control Center → Places tab
4. Click "Lookup place" button
5. Search for a place (e.g., "Berlin")
6. Select a result → Create Place modal opens
7. Verify "Place type" field is pre-populated correctly
8. Create the place - verify it saves correctly

## Screenshots (if applicable)

N/A - internal type safety improvement

## Checklist

- [x] Code follows style guidelines
- [x] Linters pass
- [x] Build succeeds
- [x] Documentation updated (N/A - no user-facing changes)
- [x] Tested in Obsidian
- [x] No sensitive data in commits