### PR TITLE
Add obituary clipping research guide

### DIFF
--- a/wiki-content/Data-Entry.md
+++ b/wiki-content/Data-Entry.md
@@ -280,6 +280,8 @@ father_id: xyz-789-uvw-012
 
 Capture genealogical data directly from web pages using [Obsidian Web Clipper](https://help.obsidian.md/Clipper). This method is ideal for collecting data from online sources like obituaries, Find A Grave, FamilySearch, and historical archives.
 
+For obituary pages, the [FinalNotes Obituary Research Guide](https://www.finalnotes.page/obituary-research-guide/) provides a practical checklist for extracting names, dates, relationships, service details, and follow-up searches before promoting clipped data into your main tree.
+
 ### Quick Overview
 
 1. Install Obsidian Web Clipper browser extension


### PR DESCRIPTION
Adds a short obituary-specific research guide reference to the Web Clipper data-entry docs. The existing section already recommends clipping genealogical data from obituaries; this note points users to a checklist for extracting names, dates, relationships, service details, and follow-up searches before promoting clipped data into the main tree.

Validation:
- git diff --check
- Confirmed https://www.finalnotes.page/obituary-research-guide/ returns HTTP 200

I did not run the JS test suite in this temporary docs-only checkout because dependencies were not installed.